### PR TITLE
Define NPY_OS_MINGW on Windows/MinGW.

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -20,7 +20,7 @@ install: build
 
 build:
 	(cd $(FORTRANDIR) && $(MINGWBIN)/gfortran.exe -fPIC -c Rutf.for Rut.for Curvif.for)
-	(cd $(FORTRANDIR) && f2py -c -I. Curvif.o Rutf.o Rut.o -m curvif_simplified curvif_simplified.pyf Curvif_simplified.f90 --compiler=mingw32 --fcompiler=gfortran)
+	(cd $(FORTRANDIR) && f2py -c -I. Curvif.o Rutf.o Rut.o -m curvif_simplified curvif_simplified.pyf Curvif_simplified.f90 --compiler=mingw32 --fcompiler=gfortran -DNPY_OS_MINGW)
 	cp -puf $(MINGWBIN)/libgcc_s_*.dll $(FORTRANDIR)
 	cp -puf $(MINGWBIN)/libgfortran*.dll $(FORTRANDIR)
 	cp -puf $(MINGWBIN)/libquadmath*.dll $(FORTRANDIR)


### PR DESCRIPTION
  - there is a small bug in numpy's f2yc which does not detect MinGW environments as it is supposed to.

    See: https://github.com/numpy/numpy/issues/24761

  - This make file is used for MinGW only. So we can just define the variable without any other checks being needed.

    This also needs a CMake configuration or at least the Makefile should be improved a bit.